### PR TITLE
1주차 기본 과제

### DIFF
--- a/src/main/java/io/hhplus/tdd/ApiControllerAdvice.java
+++ b/src/main/java/io/hhplus/tdd/ApiControllerAdvice.java
@@ -1,5 +1,7 @@
 package io.hhplus.tdd;
 
+import io.hhplus.tdd.error.ExceedMaxPointBalanceException;
+import io.hhplus.tdd.error.InvalidChargeAmountException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -7,6 +9,15 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 
 @RestControllerAdvice
 class ApiControllerAdvice extends ResponseEntityExceptionHandler {
+    @ExceptionHandler(value = ExceedMaxPointBalanceException.class)
+    public ResponseEntity<ErrorResponse> exceedMaxPointHandleException() {
+        return ResponseEntity.status(400).body(new ErrorResponse("400", "최대 보유 포인트 금액을 초과하였습니다. 올바른 충전 금액을 입력해 주세요."));
+    }
+
+    @ExceptionHandler(value = InvalidChargeAmountException.class)
+    public ResponseEntity<ErrorResponse> invalidChargeAmountHandlerException() {
+        return ResponseEntity.status(400).body(new ErrorResponse("400", "최소 충전 금액이 1원 이상입니다. 올바른 충전 금액을 입력해 주세요."));
+    }
     @ExceptionHandler(value = Exception.class)
     public ResponseEntity<ErrorResponse> handleException(Exception e) {
         return ResponseEntity.status(500).body(new ErrorResponse("500", "에러가 발생했습니다."));

--- a/src/main/java/io/hhplus/tdd/ApiControllerAdvice.java
+++ b/src/main/java/io/hhplus/tdd/ApiControllerAdvice.java
@@ -1,7 +1,9 @@
 package io.hhplus.tdd;
 
 import io.hhplus.tdd.error.ExceedMaxPointBalanceException;
+import io.hhplus.tdd.error.InsufficientPointException;
 import io.hhplus.tdd.error.InvalidChargeAmountException;
+import io.hhplus.tdd.error.InvalidUseAmountException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -18,6 +20,15 @@ class ApiControllerAdvice extends ResponseEntityExceptionHandler {
     public ResponseEntity<ErrorResponse> invalidChargeAmountHandlerException() {
         return ResponseEntity.status(400).body(new ErrorResponse("400", "최소 충전 금액이 1원 이상입니다. 올바른 충전 금액을 입력해 주세요."));
     }
+    @ExceptionHandler(value = InvalidUseAmountException.class)
+    public ResponseEntity<ErrorResponse> InvalidUseAmountHandlerException() {
+        return ResponseEntity.status(400).body(new ErrorResponse("400", "사용가능한 금액은 1원 이상, 1000000원 이하입니다. 사용하실 포인트 금액을 다시 입력해 주세요"));
+    }
+    @ExceptionHandler(value = InsufficientPointException.class)
+    public ResponseEntity<ErrorResponse> InsufficientPointHandlerException() {
+        return ResponseEntity.status(400).body(new ErrorResponse("400",  "잔액이 부족합니다. 포인트를 충전해주세요."));
+    }
+
     @ExceptionHandler(value = Exception.class)
     public ResponseEntity<ErrorResponse> handleException(Exception e) {
         return ResponseEntity.status(500).body(new ErrorResponse("500", "에러가 발생했습니다."));

--- a/src/main/java/io/hhplus/tdd/error/ExceedMaxPointBalanceException.java
+++ b/src/main/java/io/hhplus/tdd/error/ExceedMaxPointBalanceException.java
@@ -1,0 +1,8 @@
+package io.hhplus.tdd.error;
+
+public class ExceedMaxPointBalanceException extends IllegalArgumentException {
+    public static String ERROR_MESSAGE = "포인트 %d원을 충전하면 최대 포인트에서 %d원을 초과합니다.";
+    public ExceedMaxPointBalanceException(long amount, long excessAmount) {
+        super (String.format(ERROR_MESSAGE, amount, excessAmount));
+    }
+}

--- a/src/main/java/io/hhplus/tdd/error/InsufficientPointException.java
+++ b/src/main/java/io/hhplus/tdd/error/InsufficientPointException.java
@@ -1,0 +1,8 @@
+package io.hhplus.tdd.error;
+
+public class InsufficientPointException extends RuntimeException{
+    public static final String ERROR_MESSAGE = "잔액 부족입니다.";
+    public InsufficientPointException() {
+        super(ERROR_MESSAGE);
+    }
+}

--- a/src/main/java/io/hhplus/tdd/error/InvalidChargeAmountException.java
+++ b/src/main/java/io/hhplus/tdd/error/InvalidChargeAmountException.java
@@ -1,0 +1,8 @@
+package io.hhplus.tdd.error;
+
+public class InvalidChargeAmountException extends IllegalArgumentException{
+    public static String ERROR_MESSAGE = "최소 충전 금액은 1원 이상입니다.";
+    public InvalidChargeAmountException() {
+        super(ERROR_MESSAGE);
+    }
+}

--- a/src/main/java/io/hhplus/tdd/error/InvalidUseAmountException.java
+++ b/src/main/java/io/hhplus/tdd/error/InvalidUseAmountException.java
@@ -1,0 +1,8 @@
+package io.hhplus.tdd.error;
+
+public class InvalidUseAmountException extends IllegalArgumentException {
+    public static final String ERROR_MESSAGE = "사용가능 금액은 1원 이상 1000000원 이하 입니다.";
+    public InvalidUseAmountException() {
+        super(ERROR_MESSAGE);
+    }
+}

--- a/src/main/java/io/hhplus/tdd/point/PointController.java
+++ b/src/main/java/io/hhplus/tdd/point/PointController.java
@@ -31,7 +31,7 @@ public class PointController {
     public List<PointHistory> history(
             @PathVariable long id
     ) {
-        return List.of();
+        return userPointService.getPointHistory(id);
     }
 
     /**

--- a/src/main/java/io/hhplus/tdd/point/PointController.java
+++ b/src/main/java/io/hhplus/tdd/point/PointController.java
@@ -1,15 +1,17 @@
 package io.hhplus.tdd.point;
 
+import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@RequiredArgsConstructor
 @RestController
 @RequestMapping("/point")
 public class PointController {
-
+    private final UserPointService userPointService;
     private static final Logger log = LoggerFactory.getLogger(PointController.class);
 
     /**
@@ -40,7 +42,7 @@ public class PointController {
             @PathVariable long id,
             @RequestBody long amount
     ) {
-        return new UserPoint(0, 0, 0);
+        return userPointService.chargePoint(id, amount);
     }
 
     /**

--- a/src/main/java/io/hhplus/tdd/point/PointController.java
+++ b/src/main/java/io/hhplus/tdd/point/PointController.java
@@ -53,6 +53,6 @@ public class PointController {
             @PathVariable long id,
             @RequestBody long amount
     ) {
-        return new UserPoint(0, 0, 0);
+        return userPointService.usePoint(id, amount);
     }
 }

--- a/src/main/java/io/hhplus/tdd/point/PointController.java
+++ b/src/main/java/io/hhplus/tdd/point/PointController.java
@@ -21,7 +21,7 @@ public class PointController {
     public UserPoint point(
             @PathVariable long id
     ) {
-        return new UserPoint(0, 0, 0);
+        return userPointService.searchPoint(id);
     }
 
     /**

--- a/src/main/java/io/hhplus/tdd/point/PointHistory.java
+++ b/src/main/java/io/hhplus/tdd/point/PointHistory.java
@@ -1,10 +1,17 @@
 package io.hhplus.tdd.point;
 
+import java.util.Comparator;
+
 public record PointHistory(
         long id,
         long userId,
         long amount,
         TransactionType type,
         long updateMillis
-) {
+) implements Comparable<PointHistory> {
+    @Override
+    public int compareTo(PointHistory other) {
+        return Long.compare(this.updateMillis, other.updateMillis);
+    }
+    public static final Comparator<PointHistory> BY_TIME_DESC = Comparator.comparingLong(PointHistory::updateMillis).reversed();
 }

--- a/src/main/java/io/hhplus/tdd/point/UserPoint.java
+++ b/src/main/java/io/hhplus/tdd/point/UserPoint.java
@@ -1,20 +1,20 @@
 package io.hhplus.tdd.point;
 
 import io.hhplus.tdd.error.ExceedMaxPointBalanceException;
+import io.hhplus.tdd.error.InsufficientPointException;
 import io.hhplus.tdd.error.InvalidChargeAmountException;
+import io.hhplus.tdd.error.InvalidUseAmountException;
 
 public record UserPoint(
         long id,
         long point,
         long updateMillis
 ) {
-
-    public static Long MAX_POINT= 1_000_000L;
-    public static Long MIN_POINT = 0L;
+    public static final Long MAX_POINT= 1_000_000L;
+    public static final Long MIN_POINT = 0L;
     public static UserPoint empty(long id) {
         return new UserPoint(id, 0, System.currentTimeMillis());
     }
-
     public UserPoint charge(long amount) {
         long expectPoint = amount + point();
         if (MAX_POINT < expectPoint) {
@@ -24,5 +24,14 @@ public record UserPoint(
             throw new InvalidChargeAmountException();
         }
         return new UserPoint(this.id, this.point+ amount, System.currentTimeMillis());
+    }
+    public UserPoint use(long usePoint) {
+        if (usePoint < MIN_POINT || usePoint > MAX_POINT) {
+            throw new InvalidUseAmountException();
+        }
+        if (point() < usePoint) {
+            throw new InsufficientPointException();
+        }
+        return new UserPoint(id(), point() - usePoint, System.currentTimeMillis());
     }
 }

--- a/src/main/java/io/hhplus/tdd/point/UserPoint.java
+++ b/src/main/java/io/hhplus/tdd/point/UserPoint.java
@@ -1,12 +1,28 @@
 package io.hhplus.tdd.point;
 
+import io.hhplus.tdd.error.ExceedMaxPointBalanceException;
+import io.hhplus.tdd.error.InvalidChargeAmountException;
+
 public record UserPoint(
         long id,
         long point,
         long updateMillis
 ) {
 
+    public static Long MAX_POINT= 1_000_000L;
+    public static Long MIN_POINT = 0L;
     public static UserPoint empty(long id) {
         return new UserPoint(id, 0, System.currentTimeMillis());
+    }
+
+    public UserPoint charge(long amount) {
+        long expectPoint = amount + point();
+        if (MAX_POINT < expectPoint) {
+            throw new ExceedMaxPointBalanceException(amount, (expectPoint - MAX_POINT));
+        }
+        if (MIN_POINT >= amount) {
+            throw new InvalidChargeAmountException();
+        }
+        return new UserPoint(this.id, this.point+ amount, System.currentTimeMillis());
     }
 }

--- a/src/main/java/io/hhplus/tdd/point/UserPointService.java
+++ b/src/main/java/io/hhplus/tdd/point/UserPointService.java
@@ -6,6 +6,8 @@ import io.hhplus.tdd.time.TimeProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class UserPointService {
@@ -38,5 +40,10 @@ public class UserPointService {
                 timeProvider.now()
         );
         return usedUserPoint;
+    }
+    public List<PointHistory> getPointHistory(long userId) {
+        List<PointHistory> pointHistories = pointHistoryTable.selectAllByUserId(userId);
+        pointHistories.sort(PointHistory.BY_TIME_DESC);
+        return pointHistories;
     }
 }

--- a/src/main/java/io/hhplus/tdd/point/UserPointService.java
+++ b/src/main/java/io/hhplus/tdd/point/UserPointService.java
@@ -1,0 +1,27 @@
+package io.hhplus.tdd.point;
+
+import io.hhplus.tdd.database.PointHistoryTable;
+import io.hhplus.tdd.database.UserPointTable;
+import io.hhplus.tdd.time.TimeProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserPointService {
+    private final UserPointTable userPointTable;
+    private final PointHistoryTable pointHistoryTable;
+    private final TimeProvider timeProvider;
+    public UserPoint chargePoint(long userId, long amount) {
+        var userPoint = userPointTable.selectById(userId);
+        var chargedPoint = userPoint.charge(amount);
+        userPointTable.insertOrUpdate(chargedPoint.id(), chargedPoint.point());
+        pointHistoryTable.insert(
+                chargedPoint.id(),
+                userPoint.point(),
+                TransactionType.CHARGE,
+                timeProvider.now()
+        );
+        return chargedPoint;
+    }
+}

--- a/src/main/java/io/hhplus/tdd/point/UserPointService.java
+++ b/src/main/java/io/hhplus/tdd/point/UserPointService.java
@@ -24,4 +24,7 @@ public class UserPointService {
         );
         return chargedPoint;
     }
+    public UserPoint searchPoint(long userId) {
+        return userPointTable.selectById(userId);
+    }
 }

--- a/src/main/java/io/hhplus/tdd/point/UserPointService.java
+++ b/src/main/java/io/hhplus/tdd/point/UserPointService.java
@@ -27,4 +27,16 @@ public class UserPointService {
     public UserPoint searchPoint(long userId) {
         return userPointTable.selectById(userId);
     }
+    public UserPoint usePoint(long userId, long amount) {
+        var userPoint = userPointTable.selectById(userId);
+        var use = userPoint.use(amount);
+        var usedUserPoint = userPointTable.insertOrUpdate(use.id(), use.point());
+        pointHistoryTable.insert(
+                usedUserPoint.id(),
+                usedUserPoint.point(),
+                TransactionType.USE,
+                timeProvider.now()
+        );
+        return usedUserPoint;
+    }
 }

--- a/src/main/java/io/hhplus/tdd/time/SystemTimeProvider.java
+++ b/src/main/java/io/hhplus/tdd/time/SystemTimeProvider.java
@@ -1,0 +1,11 @@
+package io.hhplus.tdd.time;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class SystemTimeProvider implements TimeProvider{
+    @Override
+    public long now() {
+        return System.currentTimeMillis();
+    }
+}

--- a/src/main/java/io/hhplus/tdd/time/TimeProvider.java
+++ b/src/main/java/io/hhplus/tdd/time/TimeProvider.java
@@ -1,0 +1,5 @@
+package io.hhplus.tdd.time;
+
+public interface TimeProvider {
+    long now();
+}

--- a/src/test/java/io/hhplus/tdd/point/PointControllerTest.java
+++ b/src/test/java/io/hhplus/tdd/point/PointControllerTest.java
@@ -4,6 +4,8 @@ import io.hhplus.tdd.database.PointHistoryTable;
 import io.hhplus.tdd.database.UserPointTable;
 import io.hhplus.tdd.time.TestTimeProvider;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -17,6 +19,7 @@ import java.util.Map;
 
 import static org.mockito.BDDMockito.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -29,59 +32,107 @@ class PointControllerTest {
     @MockBean
     private UserPointTable userPointTable;
     private UserPointService userPointService;
-    @BeforeEach
-    void setUp() {
-        userPointService = new UserPointService(
-                userPointTable,
-                new PointHistoryTable(),
-                new TestTimeProvider(0L));
 
-        Map<Long, Long> fakeDb = new HashMap<>();
+    @Nested
+    @DisplayName("포인트 충전 테스트")
+    class chargeTest{
+        @BeforeEach
+        void setUp() {
+            userPointService = new UserPointService(
+                    userPointTable,
+                    new PointHistoryTable(),
+                    new TestTimeProvider(0L));
 
-        given(userPointTable.selectById(anyLong())).willAnswer(
-                i -> {
-                    long id = i.getArgument(0);
-                    Long point = fakeDb.getOrDefault(id, 0L);
-                    return new UserPoint(id, point, 0L);
-                });
+            Map<Long, Long> fakeDb = new HashMap<>();
 
-        given(userPointTable.insertOrUpdate(anyLong(), anyLong()))
-                .willAnswer(
-                        i -> {
-                            long inputId = i.getArgument(0);
-                            long inputAmount = i.getArgument(1);
-                            fakeDb.put(inputId, inputAmount);
-                            return new UserPoint(inputId, inputAmount, 0L);
-                        }
-                );
+            given(userPointTable.selectById(anyLong())).willAnswer(
+                    i -> {
+                        long id = i.getArgument(0);
+                        Long point = fakeDb.getOrDefault(id, 0L);
+                        return new UserPoint(id, point, 0L);
+                    });
+
+            given(userPointTable.insertOrUpdate(anyLong(), anyLong()))
+                    .willAnswer(
+                            i -> {
+                                long inputId = i.getArgument(0);
+                                long inputAmount = i.getArgument(1);
+                                fakeDb.put(inputId, inputAmount);
+                                return new UserPoint(inputId, inputAmount, 0L);
+                            }
+                    );
+        }
+        @Test
+        public void 유저의_포인트_충전_성공_테스트() throws Exception {
+            // Given
+            long initId = 1L;
+
+            // When && Then
+            mockMvc.perform(
+                            patch("/point/{id}/charge", initId)
+                                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                                    .content("2000")
+                    )
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.id").value(1L))
+                    .andExpect(jsonPath("$.point").value(2000));
+        }
+        @Test
+        void 포인트_충전_최대한도_초과_실패_테스트() throws Exception {
+            // Given
+            long initId = 1L;
+            userPointTable.insertOrUpdate(initId, 1_000_000L);
+
+            // When && Then
+            mockMvc.perform(patch("/point/{id}/charge", initId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("1")
+                    )
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message").value("최대 보유 포인트 금액을 초과하였습니다. 올바른 충전 금액을 입력해 주세요."));
+        }
     }
 
-    @Test
-    public void 유저의_포인트_조회_성공() throws Exception {
-        // Given
-        long initId = 1L;
+    @Nested
+    @DisplayName("포인트 조회 테스트")
+    class searchPoint {
+        @BeforeEach
+        void setUp() {
+            userPointService = new UserPointService(
+                    userPointTable,
+                    new PointHistoryTable(),
+                    new TestTimeProvider(0L));
 
-        // When && Then
-        mockMvc.perform(
-                        patch("/point/{id}/charge", initId)
-                                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                                .content("2000")
-                )
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.id").value(1L))
-                .andExpect(jsonPath("$.point").value(2000));
-    }
-    @Test
-    void 포인트_충전_최대한도_초과_실패_테스트() throws Exception {
-        // Given
-        long initId = 1L;
-        userPointTable.insertOrUpdate(initId, 1_000_000L);
+            Map<Long, Long> fakeDb = new HashMap<>();
 
-        // When && Then
-        mockMvc.perform(patch("/point/{id}/charge", initId)
-                        .content("1")
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("최대 보유 포인트 금액을 초과하였습니다. 올바른 충전 금액을 입력해 주세요."));
+            given(userPointTable.selectById(anyLong())).willAnswer(
+                    i -> {
+                        long id = i.getArgument(0);
+                        Long point = fakeDb.getOrDefault(id, 0L);
+                        return new UserPoint(id, point, 0L);
+                    });
+
+            given(userPointTable.insertOrUpdate(anyLong(), anyLong()))
+                    .willAnswer(
+                            i -> {
+                                long inputId = i.getArgument(0);
+                                long inputAmount = i.getArgument(1);
+                                fakeDb.put(inputId, inputAmount);
+                                return new UserPoint(inputId, inputAmount, 0L);
+                            }
+                    );
+        }
+        @Test
+        public void 초기유저_포인트_조회_테스트() throws Exception {
+            // Given
+            long initId = 1L;
+
+            // When && Then
+            mockMvc.perform(get("/point/{id}", initId)
+                    )
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.id").value(1L))
+                    .andExpect(jsonPath("$.point").value(0));
+        }
     }
 }

--- a/src/test/java/io/hhplus/tdd/point/PointControllerTest.java
+++ b/src/test/java/io/hhplus/tdd/point/PointControllerTest.java
@@ -1,0 +1,87 @@
+package io.hhplus.tdd.point;
+
+import io.hhplus.tdd.database.PointHistoryTable;
+import io.hhplus.tdd.database.UserPointTable;
+import io.hhplus.tdd.time.TestTimeProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.BDDMockito.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+class PointControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean
+    private UserPointTable userPointTable;
+    private UserPointService userPointService;
+    @BeforeEach
+    void setUp() {
+        userPointService = new UserPointService(
+                userPointTable,
+                new PointHistoryTable(),
+                new TestTimeProvider(0L));
+
+        Map<Long, Long> fakeDb = new HashMap<>();
+
+        given(userPointTable.selectById(anyLong())).willAnswer(
+                i -> {
+                    long id = i.getArgument(0);
+                    Long point = fakeDb.getOrDefault(id, 0L);
+                    return new UserPoint(id, point, 0L);
+                });
+
+        given(userPointTable.insertOrUpdate(anyLong(), anyLong()))
+                .willAnswer(
+                        i -> {
+                            long inputId = i.getArgument(0);
+                            long inputAmount = i.getArgument(1);
+                            fakeDb.put(inputId, inputAmount);
+                            return new UserPoint(inputId, inputAmount, 0L);
+                        }
+                );
+    }
+
+    @Test
+    public void 유저의_포인트_조회_성공() throws Exception {
+        // Given
+        long initId = 1L;
+
+        // When && Then
+        mockMvc.perform(
+                        patch("/point/{id}/charge", initId)
+                                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                                .content("2000")
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1L))
+                .andExpect(jsonPath("$.point").value(2000));
+    }
+    @Test
+    void 포인트_충전_최대한도_초과_실패_테스트() throws Exception {
+        // Given
+        long initId = 1L;
+        userPointTable.insertOrUpdate(initId, 1_000_000L);
+
+        // When && Then
+        mockMvc.perform(patch("/point/{id}/charge", initId)
+                        .content("1")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("최대 보유 포인트 금액을 초과하였습니다. 올바른 충전 금액을 입력해 주세요."));
+    }
+}

--- a/src/test/java/io/hhplus/tdd/point/PointControllerTest.java
+++ b/src/test/java/io/hhplus/tdd/point/PointControllerTest.java
@@ -1,5 +1,6 @@
 package io.hhplus.tdd.point;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.hhplus.tdd.database.PointHistoryTable;
 import io.hhplus.tdd.database.UserPointTable;
 import io.hhplus.tdd.time.TestTimeProvider;
@@ -7,6 +8,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -16,6 +20,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.mockito.BDDMockito.anyLong;
 import static org.mockito.BDDMockito.given;
@@ -29,6 +34,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class PointControllerTest {
     @Autowired
     private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
     @MockBean
     private UserPointTable userPointTable;
     private UserPointService userPointService;
@@ -150,6 +157,77 @@ class PointControllerTest {
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.id").value(1L))
                     .andExpect(jsonPath("$.point").value(amount));
+        }
+    }
+    @Nested
+    class useTest {
+        @BeforeEach
+        void setUp() {
+            userPointService = new UserPointService(
+                    userPointTable,
+                    new PointHistoryTable(),
+                    new TestTimeProvider(0L));
+
+            Map<Long, Long> fakeDb = new HashMap<>();
+
+            given(userPointTable.selectById(anyLong())).willAnswer(
+                    i -> {
+                        long id = i.getArgument(0);
+                        Long point = fakeDb.getOrDefault(id, 0L);
+                        return new UserPoint(id, point, 0L);
+                    });
+
+            given(userPointTable.insertOrUpdate(anyLong(), anyLong()))
+                    .willAnswer(
+                            i -> {
+                                long inputId = i.getArgument(0);
+                                long inputAmount = i.getArgument(1);
+                                fakeDb.put(inputId, inputAmount);
+                                return new UserPoint(inputId, inputAmount, 0L);
+                            }
+                    );
+        }
+        @Test
+        public void 포인트_사용_성공_테스트() throws Exception {
+            // Given
+            long initId = 1L;
+            long amount = 3000L;
+            long initPoint = 500_000;
+            userPointTable.insertOrUpdate(1L, initPoint);
+            String body = objectMapper.writeValueAsString(amount);
+
+            // When && Then
+            mockMvc.perform(
+                            patch("/point/{id}/use", initId)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(body))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.id").value(1L))
+                    .andExpect(jsonPath("$.point").value(initPoint - amount));
+        }
+        @ParameterizedTest
+        @MethodSource("UserPointController_Use_Fail_Test")
+        public void 포인트_사용_실패_테스트 (long initId, long initPoint, long amount, String errorMessage) throws Exception {
+            // Given
+            String body = objectMapper.writeValueAsString(amount);
+            userPointTable.insertOrUpdate(1L, initPoint);
+
+            // When && Then
+            mockMvc.perform(
+                            patch("/point/{id}/use", initId)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(body))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value(400))
+                    .andExpect(jsonPath("$.message").value(errorMessage));
+        }
+        static Stream<Arguments> UserPointController_Use_Fail_Test() {
+            return Stream.of(
+                    // 사용 가능 금액 정책을 위반 하였을 경우
+                    Arguments.of(1L, 1_000_000L, 1_000_001L, "사용가능한 금액은 1원 이상, 1000000원 이하입니다. 사용하실 포인트 금액을 다시 입력해 주세요"),
+                    // 보유 금액보다 많은 금액 사용하였을 경우
+                    Arguments.of(1L, 0L, 1L, "잔액이 부족합니다. 포인트를 충전해주세요.")
+            );
         }
     }
 }

--- a/src/test/java/io/hhplus/tdd/point/PointControllerTest.java
+++ b/src/test/java/io/hhplus/tdd/point/PointControllerTest.java
@@ -35,7 +35,7 @@ class PointControllerTest {
 
     @Nested
     @DisplayName("포인트 충전 테스트")
-    class chargeTest{
+    class chargeTest {
         @BeforeEach
         void setUp() {
             userPointService = new UserPointService(
@@ -62,6 +62,7 @@ class PointControllerTest {
                             }
                     );
         }
+
         @Test
         public void 유저의_포인트_충전_성공_테스트() throws Exception {
             // Given
@@ -77,6 +78,7 @@ class PointControllerTest {
                     .andExpect(jsonPath("$.id").value(1L))
                     .andExpect(jsonPath("$.point").value(2000));
         }
+
         @Test
         void 포인트_충전_최대한도_초과_실패_테스트() throws Exception {
             // Given
@@ -122,6 +124,7 @@ class PointControllerTest {
                             }
                     );
         }
+
         @Test
         public void 초기유저_포인트_조회_테스트() throws Exception {
             // Given
@@ -133,6 +136,20 @@ class PointControllerTest {
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.id").value(1L))
                     .andExpect(jsonPath("$.point").value(0));
+        }
+
+        @Test
+        public void 유저의_포인트를_1회_충전후_포인트_조회_테스트() throws Exception {
+            // Given
+            long initId = 1L;
+            long amount = 1_000_000L;
+            UserPoint initUserPoint = new UserPoint(initId, 0L, 0L);
+            // When && Then
+            userPointService.chargePoint(initId, amount);
+            mockMvc.perform(get("/point/{id}", initId))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.id").value(1L))
+                    .andExpect(jsonPath("$.point").value(amount));
         }
     }
 }

--- a/src/test/java/io/hhplus/tdd/point/UserPointServiceTest.java
+++ b/src/test/java/io/hhplus/tdd/point/UserPointServiceTest.java
@@ -54,4 +54,24 @@ class UserPointServiceTest {
         assertThat(chargedPoint.id()).isEqualTo(inputId);
         assertThat(chargedPoint.point()).isEqualTo(inputAmount);
     }
+    @Test
+    public void 포인트_조회_성공_케이스() throws Exception {
+        // Given
+        long initId = 1L;
+        long initPoint = 2000L;
+        given(userPointTable.selectById(anyLong())).willAnswer(
+                i -> {
+                    long id = i.getArgument(0);
+                    return new UserPoint(id, initPoint, 0L);
+                }
+        );
+
+        // When
+        UserPoint searchPoint = sut.searchPoint(initId);
+
+        // Then
+        verify(userPointTable).selectById(anyLong());
+        assertThat(searchPoint.id()).isEqualTo(initId);
+        assertThat(searchPoint.point()).isEqualTo(initPoint);
+    }
 }

--- a/src/test/java/io/hhplus/tdd/point/UserPointServiceTest.java
+++ b/src/test/java/io/hhplus/tdd/point/UserPointServiceTest.java
@@ -74,4 +74,33 @@ class UserPointServiceTest {
         assertThat(searchPoint.id()).isEqualTo(initId);
         assertThat(searchPoint.point()).isEqualTo(initPoint);
     }
+    @Test
+    public void 포인트_사용_성공_케이스() throws Exception {
+        // Given
+        long initId = 1L;
+        long initPoint = 1_000_000L;
+        long amount = 1_000_000L;
+        given(userPointTable.selectById(anyLong()))
+                .willAnswer(
+                        i -> {
+                            long inputId = i.getArgument(0);
+                            return new UserPoint(inputId, initPoint, 0L);
+                        }
+                );
+        given(userPointTable.insertOrUpdate(anyLong(), anyLong()))
+                .willAnswer(
+                        i -> {
+                            long inputId = i.getArgument(0);
+                            long inputAmount = i.getArgument(1);
+                            return new UserPoint(inputId, inputAmount, 0L);
+                        }
+                );
+        // When
+        UserPoint usedPoint = sut.usePoint(initId, amount);
+
+        // Then
+        verify(userPointTable).insertOrUpdate(anyLong(), anyLong());
+        assertThat(usedPoint.id()).isEqualTo(initId);
+        assertThat(usedPoint.point()).isEqualTo(initPoint - amount);
+    }
 }

--- a/src/test/java/io/hhplus/tdd/point/UserPointServiceTest.java
+++ b/src/test/java/io/hhplus/tdd/point/UserPointServiceTest.java
@@ -2,27 +2,38 @@ package io.hhplus.tdd.point;
 
 import io.hhplus.tdd.database.PointHistoryTable;
 import io.hhplus.tdd.database.UserPointTable;
+import io.hhplus.tdd.time.TestTimeProvider;
 import io.hhplus.tdd.time.TimeProvider;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.*;
+import java.util.concurrent.atomic.AtomicLong;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class UserPointServiceTest {
-    @InjectMocks
     private UserPointService sut;
     @Mock
     private UserPointTable userPointTable;
     @Mock
     private PointHistoryTable pointHistoryTable;
-    @Mock
     private TimeProvider timeProvider;
+
+
+    @BeforeEach
+    void setUp() {
+        timeProvider = new TestTimeProvider(0);
+        sut = new UserPointService(userPointTable, pointHistoryTable, timeProvider);
+    }
 
     @Test
     public void 포인트_충전_비즈니스영역_테스트() throws Exception {
@@ -102,5 +113,43 @@ class UserPointServiceTest {
         verify(userPointTable).insertOrUpdate(anyLong(), anyLong());
         assertThat(usedPoint.id()).isEqualTo(initId);
         assertThat(usedPoint.point()).isEqualTo(initPoint - amount);
+    }
+    @Test
+    public void 최신순으로_정렬된_포인트_내역_조회_성공_케이스() throws Exception {
+        // Given
+        AtomicLong idSeq = new AtomicLong();
+        given(pointHistoryTable.insert(anyLong(), anyLong(), any(TransactionType.class), anyLong())).willAnswer(
+                i -> {
+                    long id = idSeq.incrementAndGet();
+                    long userId = i.getArgument(0);
+                    long amount = i.getArgument(1);
+                    TransactionType type = i.getArgument(2);
+                    long time = i.getArgument(3);
+                    return new PointHistory(id, userId, amount, type, time);
+                }
+        );
+        PointHistory insert1 = pointHistoryTable.insert(1L, 2000L, TransactionType.CHARGE, timeProvider.now());
+        PointHistory insert2 = pointHistoryTable.insert(1L, 3000L, TransactionType.CHARGE, timeProvider.now());
+        PointHistory insert3 = pointHistoryTable.insert(1L, 4000L, TransactionType.USE, timeProvider.now());
+        PointHistory insert4 = pointHistoryTable.insert(1L, 5000L, TransactionType.CHARGE, timeProvider.now());
+        List<PointHistory> initLog = new ArrayList<>(List.of(insert1, insert2, insert3, insert4));
+        given(pointHistoryTable.selectAllByUserId(anyLong())).willReturn(initLog);
+        // When
+        List<PointHistory> pointHistory = sut.getPointHistory(1L);
+        // Then
+        assertThat(pointHistory)
+                .extracting(
+                        PointHistory::id,
+                        PointHistory::userId,
+                        PointHistory::amount,
+                        PointHistory::type
+                ).containsExactly(
+                        tuple(4L, 1L, 5000L, TransactionType.CHARGE),
+                        tuple(3L, 1L, 4000L, TransactionType.USE),
+                        tuple(2L, 1L, 3000L, TransactionType.CHARGE),
+                        tuple(1L, 1L, 2000L, TransactionType.CHARGE)
+                );
+        assertThat(pointHistory).extracting(PointHistory::updateMillis)
+                .isSortedAccordingTo(Comparator.reverseOrder());
     }
 }

--- a/src/test/java/io/hhplus/tdd/point/UserPointServiceTest.java
+++ b/src/test/java/io/hhplus/tdd/point/UserPointServiceTest.java
@@ -1,0 +1,57 @@
+package io.hhplus.tdd.point;
+
+import io.hhplus.tdd.database.PointHistoryTable;
+import io.hhplus.tdd.database.UserPointTable;
+import io.hhplus.tdd.time.TimeProvider;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserPointServiceTest {
+    @InjectMocks
+    private UserPointService sut;
+    @Mock
+    private UserPointTable userPointTable;
+    @Mock
+    private PointHistoryTable pointHistoryTable;
+    @Mock
+    private TimeProvider timeProvider;
+
+    @Test
+    public void 포인트_충전_비즈니스영역_테스트() throws Exception {
+        // Given
+        given(userPointTable.selectById(anyLong()))
+                .willAnswer(
+                        i -> {
+                            long inputId = i.getArgument(0);
+                            return new UserPoint(inputId, 0, 0L);
+                        }
+                );
+        given(userPointTable.insertOrUpdate(anyLong(), anyLong()))
+                .willAnswer(
+                        i -> {
+                            long inputId = i.getArgument(0);
+                            long inputAmount = i.getArgument(1);
+                            return new UserPoint(inputId, inputAmount, 0L);
+                        }
+                );
+        long inputId = 1L;
+        long inputAmount = 2000L;
+        // When
+        UserPoint chargedPoint = sut.chargePoint(inputId, inputAmount);
+
+        // Then
+        verify(userPointTable).insertOrUpdate(anyLong(), anyLong());
+        verify(userPointTable).selectById(anyLong());
+        verify(pointHistoryTable).insert(anyLong(), anyLong(), any(TransactionType.class), anyLong());
+        assertThat(chargedPoint.id()).isEqualTo(inputId);
+        assertThat(chargedPoint.point()).isEqualTo(inputAmount);
+    }
+}

--- a/src/test/java/io/hhplus/tdd/point/UserPointTest.java
+++ b/src/test/java/io/hhplus/tdd/point/UserPointTest.java
@@ -1,0 +1,38 @@
+package io.hhplus.tdd.point;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserPointTest {
+
+//    # 정책
+//    - 포인트는 최대 100만원, 최소 0원까지 포인트를 보유할 수 있다.
+//    - 포인트 0원 이하 충전 시도 시 실패 처리 (IlligalArgumentException)
+//    - 포인트 충전 시 히스토리 기록
+
+//      1. 포인트를 충전 시 보유 포인트가 99_999원 일 경우 성공 케이스
+//      2. 포인트를 충전 시 보유 포인트가 100_000원 일 경우 성공 케이스
+//      3. 포인트를 충전 시 보유 포인트가 100_001원 일 경우 실패 케이스 : ExceededPointException / "~원 을 더 하면 최대 포인트 값 ~원을 초과합니다."
+//      4. 포인트 0원 이하의 금액을 충전했을 때 실패 케이스 : IlligalArgumentException / "충전 금액은 1원 이상이어야 합니다."
+//      5. amount 파라미터가 null 이거나, 문자형태 일 경우 테스트 : BadRequest / "amount 는 필수 이며 숫자여야 합니다."
+@Nested
+@DisplayName("포인트 충전 테스트")
+    class chargeTest{
+        @Test
+        public void 포인트_충전_In_Range_성공_케이스() throws Exception {
+            // Given
+            long initUserId = 1L;
+            UserPoint initUser = UserPoint.empty(initUserId);
+            long input = 99_999L;
+            var chargedPoint = initUser.charge(input);
+            // When
+
+            // Then
+            assertThat(chargedPoint.point()).isEqualTo(input);
+        }
+    }
+}

--- a/src/test/java/io/hhplus/tdd/point/UserPointTest.java
+++ b/src/test/java/io/hhplus/tdd/point/UserPointTest.java
@@ -1,38 +1,76 @@
 package io.hhplus.tdd.point;
 
-import org.assertj.core.api.Assertions;
+import io.hhplus.tdd.error.ExceedMaxPointBalanceException;
+import io.hhplus.tdd.error.InvalidChargeAmountException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 class UserPointTest {
-
-//    # 정책
-//    - 포인트는 최대 100만원, 최소 0원까지 포인트를 보유할 수 있다.
-//    - 포인트 0원 이하 충전 시도 시 실패 처리 (IlligalArgumentException)
-//    - 포인트 충전 시 히스토리 기록
-
-//      1. 포인트를 충전 시 보유 포인트가 99_999원 일 경우 성공 케이스
-//      2. 포인트를 충전 시 보유 포인트가 100_000원 일 경우 성공 케이스
-//      3. 포인트를 충전 시 보유 포인트가 100_001원 일 경우 실패 케이스 : ExceededPointException / "~원 을 더 하면 최대 포인트 값 ~원을 초과합니다."
-//      4. 포인트 0원 이하의 금액을 충전했을 때 실패 케이스 : IlligalArgumentException / "충전 금액은 1원 이상이어야 합니다."
-//      5. amount 파라미터가 null 이거나, 문자형태 일 경우 테스트 : BadRequest / "amount 는 필수 이며 숫자여야 합니다."
-@Nested
-@DisplayName("포인트 충전 테스트")
-    class chargeTest{
-        @Test
-        public void 포인트_충전_In_Range_성공_케이스() throws Exception {
+    @Nested
+    @DisplayName("포인트 충전 테스트")
+    class chargeTest {
+        @ParameterizedTest
+        @MethodSource("UserPoint_have_0_input_data")
+        public void 포인트_충전_In_Range_성공_케이스(long id, long amount) throws Exception {
             // Given
-            long initUserId = 1L;
-            UserPoint initUser = UserPoint.empty(initUserId);
-            long input = 99_999L;
-            var chargedPoint = initUser.charge(input);
+            UserPoint initUser = UserPoint.empty(id);
             // When
-
+            var chargedPoint = initUser.charge(amount);
             // Then
-            assertThat(chargedPoint.point()).isEqualTo(input);
+            assertThat(chargedPoint.point()).isLessThanOrEqualTo(UserPoint.MAX_POINT);
+        }
+        static Stream<Arguments> UserPoint_have_0_input_data() {
+            return Stream.of(
+                    Arguments.of(1L, 1_000_000L),
+                    Arguments.of(1L, 999_999L)
+            );
+        }
+        @ParameterizedTest
+        @MethodSource("UserPoint_have1000_input_data")
+        public void 포인트_보유된_상태에서_포인트_충전_In_Range_성공_케이스(long id, long amount) throws Exception {
+            // Given
+            UserPoint initUser = new UserPoint(id, 1_000L, 0L);
+            // When
+            var chargedPoint = initUser.charge(amount);
+            // Then
+            assertThat(chargedPoint.point()).isLessThanOrEqualTo(UserPoint.MAX_POINT);
+        }
+        static Stream<Arguments> UserPoint_have1000_input_data() {
+            return Stream.of(
+                    Arguments.of(1L, 999_000L),
+                    Arguments.of(1L, 998_999L)
+            );
+        }
+        @Test
+        public void 포인트_충전_Out_of_Range_실패_케이스() throws Exception {
+            // Given
+            long inputId = 1L;
+            UserPoint initUser = UserPoint.empty(inputId);
+            long inputPoint = 1_000_001L;
+            // When && Then
+            assertThatExceptionOfType(ExceedMaxPointBalanceException.class)
+                    .isThrownBy(() -> initUser.charge(inputPoint))
+                    .withMessage(String.format(ExceedMaxPointBalanceException.ERROR_MESSAGE, inputPoint, inputPoint - UserPoint.MAX_POINT));
+        }
+        @Test
+        public void 포인트_충전_최소금액_정책에_따른_실패_케이스() throws Exception {
+            // Given
+            long inputId = 1L;
+            UserPoint initUser = UserPoint.empty(inputId);
+            long inputPoint = 0L;
+            // When && Then
+            assertThatExceptionOfType(InvalidChargeAmountException.class)
+                    .isThrownBy(() -> initUser.charge(inputPoint))
+                    .withMessage(InvalidChargeAmountException.ERROR_MESSAGE);
         }
     }
 }

--- a/src/test/java/io/hhplus/tdd/time/TestTimeProvider.java
+++ b/src/test/java/io/hhplus/tdd/time/TestTimeProvider.java
@@ -1,12 +1,12 @@
 package io.hhplus.tdd.time;
 
 public class TestTimeProvider implements TimeProvider{
-    private final long fixedTime;
+    private long fixedTime;
     public TestTimeProvider(long time) {
         this.fixedTime = time;
     }
     @Override
     public long now() {
-        return this.fixedTime;
+        return this.fixedTime++;
     }
 }

--- a/src/test/java/io/hhplus/tdd/time/TestTimeProvider.java
+++ b/src/test/java/io/hhplus/tdd/time/TestTimeProvider.java
@@ -1,0 +1,12 @@
+package io.hhplus.tdd.time;
+
+public class TestTimeProvider implements TimeProvider{
+    private final long fixedTime;
+    public TestTimeProvider(long time) {
+        this.fixedTime = time;
+    }
+    @Override
+    public long now() {
+        return this.fixedTime;
+    }
+}


### PR DESCRIPTION
### **커밋 링크**

충전 기능 : f6e97f1

사용 기능 : 9ae31d5

포인트 조회 기능 : d71e477

유저 포인트 충전/사용 내역 조회 기능 : 71d15cb

---
### **리뷰 포인트(질문)**
- 리뷰 포인트 1   : UserPoint의 상태와 역할을 서비스 계층으로부터 구분하여 테스트하기 수월하였다고 생각하는데 적절한 방법이었는지 검토 부탁드립니다. (UserPoint는 테스트 하기 수월해졌지만, UserPointService가 테스트 하기 어려워졌다고 느껴졌기 괜찮은 방식인지 궁금합니다.)
- 
- 리뷰 포인트 2 : 포인트 사용/충전 내역 조회 기능에 대해 테스트 케이스가 부족하다고 느껴지는데 어떤 점을 보완하면 좋을지 확인해주시면 감사드립니다.
<!-- - 리뷰어가 특히 확인해야 할 부분이나 신경 써야 할 코드가 있다면 명확히 작성해주세요.(최대 2개)

---


# 충전 테스트에 대한 단위 테스트 케이스
# 정책
    - 포인트는 최대 100만원, 최소 0원까지 포인트를 보유할 수 있다.
    - 포인트 0원 이하 충전 시도 시 실패 처리 (IlligalArgumentException)
    - 포인트 충전 시 히스토리 기록

1. 포인트를 충전 시 보유 포인트가 99_999원 일 경우 성공 케이스
2. 포인트를 충전 시 보유 포인트가 100_000원 일 경우 성공 케이스
3. 포인트를 충전 시 보유 포인트가 100_001원 일 경우 실패 케이스 : ExceededPointException / "~원 을 더 하면 최대 포인트 값 ~원을 초과합니다."
4. 포인트 0원 이하의 금액을 충전했을 때 실패 케이스 : IlligalArgumentException / "충전 금액은 1원 이상이어야 합니다."
5. 동시성/트랜잭션 이슈 (Optional , 통합 테스트)
    - 두 스레드가 동일 계정에 거의 동시에 충전 시도 : 트랜잭션 롤백 혹은 순차 처리로 최종 잔액 계산

# 포인트 사용에 대한 테스트 케이스
# 정책
    - 포인트는 0원 이상 보유 가능
    - 포인트는 0이하의 금액을 사용할 수 없음
    - 포인트 사용 시 보유 포인트 보다 많으면 실패
    - 사용할 수 있는 최대 포인트는 1_000_000원
    - 포인트 사용 시 히스토리 기록
1. 보유 포인트가 1_000_000원 일 때, 999_999원 사용 성공 케이스
2. 보유 포인트가 1_000_000원 일 때, 1_000_000원 사용 성공 케이스
3. 보유 포인트가 1_000원일 때, 1_001원 사용 시 실패 케이스
4. 사용하려는 포인트가 1_000_001원 일 경우 실패 케이스
5. 사용하려는 포인트가 0원일 경우 실패 케이스 : IlligalArgumentException / "사용 금액은 1원 이상이어야 합니다."

# 포인트 조회에 대한 테스트
# 정책
    - 없음
1. 포인트 조회 하기
2. 포인트 충전/사용 이후 변경된 포인트 테스트



# 포인트 내역 조회 테스트
# 정책
    - 포인트 조회 내역은 항상 최신순 
2. 최신 순으로 정렬된 유저별 포인트 사용 내역 필터링 조회 시 성공 케이스
3. 최신 순으로 정렬된 유저별 포인트 충전/사용 내역 전체 조회 시 성공 케이스


### **이번주 KPT 회고**

### Keep

<!-- 유지해야 할 좋은 점 -->
- 지금 열정 이대로 공부할 것

### Problem
<!--개선이 필요한 점-->
- 시간 관리가 필요함
- 모르는 내용이 있을 때 바로바로 물어보고, 개선할 사항은 적극 반영이 필요함
### Try
<!-- 새롭게 시도할 점 -->
- 적절히 학습이 되었다면, 코드를 먼저 작성하고, 개선할 사항이 있는지 확인하는 등 점진적으로 공부를 해볼 것
